### PR TITLE
fix: two more match order on zhCN locale

### DIFF
--- a/parser-vanilla.lua
+++ b/parser-vanilla.lua
@@ -166,6 +166,10 @@ local combatlog_strings = {
   },
   { -- %s suffers %d %s damage from %s's %s.
     prepare(PERIODICAURADAMAGEOTHEROTHER), function(d, target, value, school, source, attack)
+      -- zhCN: %4$s的%5$s使%1$s受到了%2$d点%3$s伤害。
+      if GetLocale() == "zhCN" then
+        target, value, school, source, attack = school, source, attack, target, value
+      end
       return source, attack, target, value, school, "damage"
     end
   },
@@ -210,6 +214,10 @@ local combatlog_strings = {
   },
   { -- You gain %d health from %s.
     prepare(PERIODICAURAHEALSELFSELF), function(d, value, spell)
+      -- zhCN: 你因%2$s而获得了%1$d点生命值。
+      if GetLocale() == "zhCN" then
+        value, spell = spell, value
+      end
       return d.source, spell, d.target, value, d.school, "heal"
     end
   },


### PR DESCRIPTION
![error1](https://user-images.githubusercontent.com/54968620/205429454-c3ea3cb8-c9d5-41d9-8a65-2531bca55e14.png)

the above error message point to the healing effective calculator, but i know that all difference is because of zhCN client's format strings. so i have to check all *combatlog_strings* and find out 2 more placeholder order mismatch.