### PR TITLE
window: add new command to use pastel class colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,6 @@ Available options are:
 /sdps bars 8           Visible Bars (any number)
 /sdps trackall 0       Track all nearby units (0 or 1)
 /sdps texture 2        Set the statusbar texture (1 to 4)
+/sdps pastel 0         Use pastel colors (0 or 1)
 /sdps toggle           Toggle visibility of the main window
 ```

--- a/core.lua
+++ b/core.lua
@@ -76,6 +76,7 @@ local config = {
   -- appearance
   visible = 1,
   texture = 2,
+  pastel = 0,
 
   -- window
   view = 1,

--- a/settings.lua
+++ b/settings.lua
@@ -38,6 +38,7 @@ SlashCmdList["SHAGUMETER"] = function(msg, editbox)
     p("  /sdps trackall " .. config.track_all_units .. " |cffcccccc- Track all nearby units")
     p("  /sdps mergepet " .. config.merge_pets .. " |cffcccccc- Merge pets into owner data")
     p("  /sdps texture " .. config.texture .. " |cffcccccc- Set the statusbar texture")
+    p("  /sdps pastel " .. config.pastel .. " |cffcccccc- Use pastel colors")
     p("  /sdps toggle |cffcccccc- Toggle window")
     return
   end
@@ -127,6 +128,16 @@ SlashCmdList["SHAGUMETER"] = function(msg, editbox)
       p("|cffffcc00Shagu|cffffffffDPS:|cffffddcc Texture: " .. config.texture)
     else
       p("|cffffcc00Shagu|cffffffffDPS:|cffff5511 Valid Options are 1-" .. table.getn(textures))
+    end
+  elseif strlower(cmd) == "pastel" then
+    if tonumber(args) and (tonumber(args) == 1 or tonumber(args) == 0) then
+      config.pastel = tonumber(args)
+      ShaguDPS_Config = config
+      window.Refresh(true)
+
+      p("|cffffcc00Shagu|cffffffffDPS:|cffffddcc Use pastel colors: " .. config.pastel)
+    else
+      p("|cffffcc00Shagu|cffffffffDPS:|cffff5511 Valid Options are 0-1")
     end
   end
 end

--- a/window.lua
+++ b/window.lua
@@ -654,6 +654,12 @@ window.GetData = function(unitdata, values)
     values.color.r = RAID_CLASS_COLORS[data["classes"][unit]].r
     values.color.g = RAID_CLASS_COLORS[data["classes"][unit]].g
     values.color.b = RAID_CLASS_COLORS[data["classes"][unit]].b
+
+    if config.pastel == 1 then
+      values.color.r = (values.color.r + .5) * .5
+      values.color.g = (values.color.g + .5) * .5
+      values.color.b = (values.color.b + .5) * .5
+    end
   end
 
   return values


### PR DESCRIPTION
This adds the `/sdps pastel` command for enabling pastel class colors (disabled by default). When enabled, the pastel color values are calculated the same way as [in pfUI](https://github.com/shagu/pfUI/blob/master/api/unitframes.lua#L1841-L1843): by calculating `(x + .5) * .5` for each of the individual R/G/B values.