### PR TITLE
implement /sdps border

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,6 @@ Available options are:
 /sdps trackall 0       Track all nearby units (0 or 1)
 /sdps texture 2        Set the statusbar texture (1 to 4)
 /sdps pastel 0         Use pastel colors (0 or 1)
+/sdps border           Toggle Borderless mode on and off
 /sdps toggle           Toggle visibility of the main window
 ```

--- a/settings.lua
+++ b/settings.lua
@@ -17,6 +17,20 @@ settings:SetScript("OnEvent", function()
   end
 
   ShaguDPS_Config = config
+  
+  if config.borders == 0 then
+	window.border:Hide()
+	window:SetBackdrop(nil)
+  else
+	window.border:Show()
+	window:SetBackdrop({
+	  bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+	  tile = true, tileSize = 16, edgeSize = 16,
+	  insets = { left = 3, right = 3, top = 3, bottom = 3 }
+	})
+	window:SetBackdropColor(.5,.5,.5,.5)
+	end
+	
   window.Refresh(true)
 end)
 
@@ -37,6 +51,7 @@ SlashCmdList["SHAGUMETER"] = function(msg, editbox)
     p("  /sdps bars " .. config.bars .. " |cffcccccc- Visible Bars")
     p("  /sdps trackall " .. config.track_all_units .. " |cffcccccc- Track all nearby units")
     p("  /sdps mergepet " .. config.merge_pets .. " |cffcccccc- Merge pets into owner data")
+	p("  /sdps borders " .. config.borders .. " |cffcccccc- Visible Borders")
     p("  /sdps texture " .. config.texture .. " |cffcccccc- Set the statusbar texture")
     p("  /sdps pastel " .. config.pastel .. " |cffcccccc- Use pastel colors")
     p("  /sdps toggle |cffcccccc- Toggle window")
@@ -139,5 +154,21 @@ SlashCmdList["SHAGUMETER"] = function(msg, editbox)
     else
       p("|cffffcc00Shagu|cffffffffDPS:|cffff5511 Valid Options are 0-1")
     end
+  elseif strlower(cmd) == "borders" then
+    config.borders = config.borders == 1 and 0 or 1
+    ShaguDPS_Config = config
+	if config.borders == 0 then
+		window.border:Hide()
+		window:SetBackdrop(nil)
+	else
+		window.border:Show()
+		window:SetBackdrop({
+		  bgFile = "Interface\\Tooltips\\UI-Tooltip-Background",
+		  tile = true, tileSize = 16, edgeSize = 16,
+		  insets = { left = 3, right = 3, top = 3, bottom = 3 }
+		})
+		window:SetBackdropColor(.5,.5,.5,.5)
+	end
+    p("|cffffcc00Shagu|cffffffffDPS:|cffffddcc Borders: " .. config.borders)
   end
 end


### PR DESCRIPTION
allows to toggle the border and background off for a smaller screen impact
![image](https://user-images.githubusercontent.com/25199983/210765748-3f8d57db-697e-419d-8607-7bad2ddf0be3.png)
